### PR TITLE
fix for dropped changesets elements

### DIFF
--- a/lib/parsers/AugmentedDiffParser.js
+++ b/lib/parsers/AugmentedDiffParser.js
@@ -25,7 +25,7 @@ function AugmentedDiffParser (xmlData) {
         if (changesetMap[changeset]) {
           changesetMap[changeset].push(currentElement);
         } else {
-          changesetMap[changeset] = [];
+          changesetMap[changeset] = [currentElement];
         }
       }
       if (symbol === 'osm') {

--- a/lib/utils/splitter.js
+++ b/lib/utils/splitter.js
@@ -3,7 +3,7 @@ var R = require('ramda');
 // Takes a changeset from the stream and splits it
 // into an array of changesets
 module.exports = function (changeset, limit) {
-  if (!R.has('elements', changeset) || limit < 1 || changeset.elements.length === 1) {
+  if (!R.has('elements', changeset) || limit < 1 || changeset.elements.length <= 1) {
     return [changeset];
   }
   var numElements = changeset.elements.length;


### PR DESCRIPTION
fixes https://github.com/developmentseed/planet-stream/issues/16

I tracked down what is happening here. The data elements are saved as an empty array. If opts.limits is set, the 1 changeset is "split" into 0 changesets because it maps using the elements. 

Part of the confusion is probably that Ramda .has() returns true for an empty array  http://goo.gl/xqLZ0Z
