### PR TITLE
Emit changesets rather than Promises

### DIFF
--- a/lib/planetstream.js
+++ b/lib/planetstream.js
@@ -98,7 +98,7 @@ function PlanetStream (opts) {
     return redis.get(id).then(function (result) {
       job.log('[metadata found]: ' + result);
       if (result && result.match(/.*user.*/)) { // If the result is metadata, it has a user field
-        return result;
+        return JSON.parse(result);
       }
       else {
         throw(new Error('metadata not found'));
@@ -119,8 +119,14 @@ function PlanetStream (opts) {
     log.debug(`processing ${changeset_id}`);
     return findMetadata(changeset_id, job)
       .then(function (metadata) {
-        ps_emitter.emit('metadata', metadata);
-        done(null, changeset_id);
+        redis.get('data:' + metadata.id).then(function(data) {
+          var fullChangeset = {};
+          fullChangeset.metadata = metadata;
+          fullChangeset.elements = JSON.parse(data) || [];
+          log.debug('Parsing full changeset complete');
+          ps_emitter.emit('changeset', fullChangeset);
+          done(null, changeset_id);
+        });
       })
       .catch( function (err) {
         done(err);
@@ -133,17 +139,7 @@ function PlanetStream (opts) {
    * When the event is triggered, grab data from redis, combine it
    * and send it to the stream
    */
-  var PlanetStreamEvents = K.fromEvents(ps_emitter, 'metadata');
-  var changesets = PlanetStreamEvents.map(function (metadata) {
-    log.debug('Retrieving data and creating full changeset');
-    return redis.get('data:' + metadata.id).then(function(data) {
-      var fullChangeset = {};
-      fullChangeset.metadata = metadata;
-      fullChangeset.elements = JSON.parse(data);
-      log.debug('Parsing full changeset complete');
-      return fullChangeset;
-    });
-  });
+  var changesets = K.fromEvents(ps_emitter, 'changeset');
 
   if (opts && opts.limit) {
     return changesets.map(function (changeset) {


### PR DESCRIPTION
Previously, Promises that resolved to changesets were emitted due to the use of Redis promises within PlanetStreamEvents.map

Fixes #21